### PR TITLE
Bump repository/mocaccino-desktop-stable to 20230811164654

### DIFF
--- a/packages/collection.yaml
+++ b/packages/collection.yaml
@@ -30,8 +30,8 @@ packages:
         skopeo list-tags docker://quay.io/mocaccino/desktop | jq -rc '.Tags | map(select(. | contains("-repository.yaml"))) | sort | .[-1]'
       autobump.version_hook: |
         skopeo list-tags docker://quay.io/mocaccino/desktop | jq -rc '.Tags | map(select(. | contains("-repository.yaml"))) | sort | .[-1]' | sed "s/-repository.yaml//g"
-      package.version: "20230923194055-repository.yaml"
-    version: "20230923194055"
+      package.version: "20230924104558-repository.yaml"
+    version: "20230924104558"
   - category: "repository"
     name: "mocaccino-extra"
     version: "20211023"

--- a/packages/updater/collection.yaml
+++ b/packages/updater/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &base
     category: "repo-updater"
     name: "mocaccino-desktop-stable"
-    version: "0.2+97"
+    version: 0.2+98
     requires:
       - category: "repository"
         name: "mocaccino-desktop-stable"


### PR DESCRIPTION
git is one byte short of a four-letter word